### PR TITLE
Deleting no longer requires reloading

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -73,7 +73,7 @@ public class DataServlet extends HttpServlet {
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     
-    List<String> commentsList = new ArrayList();
+    ArrayList<String> commentsList = new ArrayList();
 
     Query commentsQuery = new Query("Comment");
     PreparedQuery results = datastore.prepare(commentsQuery);

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -20,9 +20,6 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.gson.Gson;
-import java.util.Arrays;
-import java.util.List;
-import java.util.ArrayList;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -45,6 +42,12 @@ public class DeleteDataServlet extends HttpServlet {
       datastore.delete(entity.getKey());
     }
 
-    response.sendRedirect("/");
+    Gson gson = new Gson();
+    String json = gson.toJson(true);
+
+    response.setContentType("application/json;");
+    response.getWriter().println(json);
+
+    // response.sendRedirect("/");
   }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -156,7 +156,7 @@
             <h5>Delete Comments: </h5>
           </label>
           <br>
-          <button id="cmt_del_button" type="button" class="btn btn-danger">Delete</button>
+          <button id="cmt_del_button" type="button" name="del_btn" class="btn btn-danger">Delete</button>
         </form>
         <br>
         <br>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -39,7 +39,7 @@ function randQuote() {
 // Fetch comments from DataServlet.java
 function getComments() {
 
-  fetch('/comments').then(response => response.json()).then((cmtContainer) => {
+  fetch('/comments', { method: 'GET' }).then(response => response.json()).then((cmtContainer) => {
 
     const commentsArray = Array.from(cmtContainer);
 
@@ -59,12 +59,11 @@ function getComments() {
     });
 
     commentsOutput.appendChild(cmtDOM);
-    return false;
   });
 }
 
 window.addEventListener("DOMContentLoaded", function() {
-  
+
   randQuote();
   getComments();
 
@@ -76,6 +75,24 @@ window.addEventListener("DOMContentLoaded", function() {
   });
 
   document.getElementById("cmt_del_button").addEventListener("click", function() {
-    cmt_del_form.submit();
+    // cmt_del_form.submit();
+
+    fetch('/delete-cmt', { method: 'POST' }).then(response => response.json()).then((del_bool) => {
+
+      console.log(del_bool);
+
+      if (del_bool) {
+
+        const commentsOutput = document.getElementById("comments-output");
+
+        // Delete comments using DOM API
+        commentsOutput.parentNode.removeChild(commentsOutput);
+
+      }
+    });
+
+
+
+
   });
 });


### PR DESCRIPTION
When the delete key is clicked, the comments are immediately deleted from the page.

Same issue still applies though. 

The comments are deleted for the current page, yet if you immediately refresh the some comments will be written to the page. If you wait a couple of seconds the no comments should appear. 